### PR TITLE
Feature: 여행 PDF 변환하기 기능 (#67)

### DIFF
--- a/GILLsDREAM-iOS.xcodeproj/project.pbxproj
+++ b/GILLsDREAM-iOS.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sammy.GILLsDREAM-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sammy.GILLsDREAM-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/GILLsDREAM-iOS/Data/RepositoryImplement/PlanRepositoryImpl.swift
+++ b/GILLsDREAM-iOS/Data/RepositoryImplement/PlanRepositoryImpl.swift
@@ -130,4 +130,26 @@ final class PlanRepositoryImpl: PlanRepository {
         }
         return dto
     }
+    
+    @discardableResult
+    func exportPlanPDF(planId: Int, title: String) async throws -> URL {
+        let res = try await provider.asyncRequest(.exportPDF(planId: planId))
+        guard (200..<300).contains(res.statusCode) else {
+            throw NetworkError.server(
+                (try? JSONDecoder().decode(ErrorResponse.self, from: res.data))
+                ?? .init(code: "HTTP_\(res.statusCode)", message: "PDF 내보내기 실패"),
+                status: res.statusCode
+            )
+        }
+
+        let safeTitle = title
+            .replacingOccurrences(of: "[/:]", with: "_", options: .regularExpression)
+//            .replacingOccurrences(of: "[^0-9a-zA-Z가-힣!?]", with: "_", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let filename = (safeTitle.isEmpty ? "plan" : safeTitle) + ".pdf"
+
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try res.data.write(to: url, options: .atomic)
+        return url
+    }
 }

--- a/GILLsDREAM-iOS/Data/TargetType/PlanTargetType.swift
+++ b/GILLsDREAM-iOS/Data/TargetType/PlanTargetType.swift
@@ -22,6 +22,7 @@ enum PlanTargetType {
     case fetchGeneratedPlanSummary(planId: Int)
     case profile(planId: Int, title: String, imageData: Data?)
     case list
+    case exportPDF(planId: Int)
 }
 
 extension PlanTargetType: BaseTargetType {
@@ -53,6 +54,8 @@ extension PlanTargetType: BaseTargetType {
             return "/v1/plan/template/\(id)/profile"
         case .list:
             return "/v1/plan/template"
+        case .exportPDF(let id):
+            return "v1/plan/\(id)/export/pdf"
         }
     }
     
@@ -62,7 +65,7 @@ extension PlanTargetType: BaseTargetType {
             return .post
         case .region, .videos, .duration, .style, .companion, .patchGeneratedPlanSummary, .profile:
             return .patch
-        case .list, .fetchGeneratedPlan, .fetchGeneratedPlanSummary:
+        case .list, .fetchGeneratedPlan, .fetchGeneratedPlanSummary, .exportPDF:
             return .get
         }
     }
@@ -90,7 +93,7 @@ extension PlanTargetType: BaseTargetType {
         case .destination(_, let travel, let stay):
             return .requestJSONEncodable(DestinationRequestDTO(travelPlaceDtoList: travel, stayPlaceDtoList: stay))
             
-        case .generate, .list, .fetchGeneratedPlan, .patchGeneratedPlanSummary, .fetchGeneratedPlanSummary:
+        case .generate, .list, .fetchGeneratedPlan, .patchGeneratedPlanSummary, .fetchGeneratedPlanSummary, .exportPDF:
             return .requestPlain
             
         case let .profile(_, title, imageData):
@@ -135,6 +138,9 @@ extension PlanTargetType: BaseTargetType {
                 return ["Authorization": "Bearer \(token)"]
             }
             return nil
+            
+        case .exportPDF:
+                return ["Accept": "application/pdf, application/octet-stream"]
 
         default:
             return ["Content-Type": "application/json",

--- a/GILLsDREAM-iOS/Data/TargetType/PlanTargetType.swift
+++ b/GILLsDREAM-iOS/Data/TargetType/PlanTargetType.swift
@@ -55,7 +55,7 @@ extension PlanTargetType: BaseTargetType {
         case .list:
             return "/v1/plan/template"
         case .exportPDF(let id):
-            return "v1/plan/\(id)/export/pdf"
+            return "/v1/plan/\(id)/export/pdf"
         }
     }
     

--- a/GILLsDREAM-iOS/Domain/RepositoryInterface/PlanRepository.swift
+++ b/GILLsDREAM-iOS/Domain/RepositoryInterface/PlanRepository.swift
@@ -21,4 +21,4 @@ protocol PlanRepository {
     func patchGeneratedPlanSummary(planId: Int) async throws -> PlanSummaryResponseDTO
     func updatePlanProfile(planId: Int, title: String, imageData: Data?) async throws -> PlanIdResultDTO
     func fetchPlanList() async throws -> [Plan]
-}
+    func exportPlanPDF(planId: Int, title: String) async throws -> URL}

--- a/GILLsDREAM-iOS/Domain/Usecase/PlanUsecase.swift
+++ b/GILLsDREAM-iOS/Domain/Usecase/PlanUsecase.swift
@@ -21,6 +21,7 @@ protocol PlanUsecase {
     func patchGeneratedPlanSummary(planId: Int) async throws -> PlanSummary
     func fetchMyPlans() async throws -> [Plan]
     func updatePlanProfile(planId: Int, title: String, imageData: Data?) async throws -> PlanIdResultDTO
+    func exportPlanPDF(planId: Int, title: String) async throws -> URL
 }
 
 final class PlanUsecaseImpl: PlanUsecase {
@@ -86,5 +87,9 @@ final class PlanUsecaseImpl: PlanUsecase {
     func updatePlanProfile(planId: Int, title: String, imageData: Data?) async throws -> PlanIdResultDTO {
         let result = try await repository.updatePlanProfile(planId: planId, title: title, imageData: imageData)
         return result
+    }
+    
+    func exportPlanPDF(planId: Int, title: String) async throws -> URL {
+        try await repository.exportPlanPDF(planId: planId, title: title)
     }
 }

--- a/GILLsDREAM-iOS/Presentation/PlanList/Cell/PlanListCollectionViewCell.swift
+++ b/GILLsDREAM-iOS/Presentation/PlanList/Cell/PlanListCollectionViewCell.swift
@@ -22,7 +22,7 @@ final class PlanListCollectionViewCell: UICollectionViewCell {
     let detailButton = UIButton()
     
     //MARK: events
-    var onConvertToPDF: (() -> Void)?
+    var onConvertToPDF: ((Plan, UIView) -> Void)?
     var onUnpin: (() -> Void)?
     var onPin: (() -> Void)?
     var onShare: (() -> Void)?
@@ -108,35 +108,27 @@ final class PlanListCollectionViewCell: UICollectionViewCell {
             $0.leading.equalTo(pinImageView).offset(7)
         }
         
-//        detailButton.snp.makeConstraints {
-//            $0.trailing.centerY.equalToSuperview()
-//            $0.size.equalTo(20)
-//        }
+        detailButton.snp.makeConstraints {
+            $0.trailing.centerY.equalToSuperview()
+            $0.size.equalTo(20)
+        }
     }
     
-    private func setUpMenu(isPinned: Bool) {
+    private func setUpMenu(with model: Plan) {
         let pdfAction = UIAction(title: "PDF 변환",
-                                 image: UIImage(systemName: "doc.fill")
-        ) { [weak self] _ in
-            self?.onConvertToPDF?()
+                                 image: UIImage(systemName: "doc.fill")) { [weak self] _ in
+            guard let self else { return }
+            self.onConvertToPDF?(model, self.detailButton)
         }
         
-        let pinToggleAction = UIAction(
-            title: isPinned ? "고정 해제" : "고정하기",
-            image: UIImage(systemName: isPinned ? "pin.slash.fill" : "pin.fill")
-        ) { [weak self] _ in
-            isPinned ? self?.onUnpin?() : self?.onPin?()
-        }
-
-        let shareAction = UIAction(title: "공유하기",
-                                   image: UIImage(systemName: "square.and.arrow.up")
-        ) { [weak self] _ in
-            self?.onShare?()
-        }
+//        let shareAction = UIAction(title: "공유하기",
+//                                   image: UIImage(systemName: "square.and.arrow.up")
+//        ) { [weak self] _ in
+//            self?.onShare?()
+//        }
+        
         detailButton.showsMenuAsPrimaryAction = true
-        detailButton.menu = UIMenu(title: "", children: [pdfAction,
-                                                         pinToggleAction,
-                                                         shareAction])
+        detailButton.menu = UIMenu(title: "", children: [pdfAction])
     }
 }
 
@@ -148,7 +140,7 @@ extension PlanListCollectionViewCell {
         planDate.attributedText = model.dateRange?.pretendardAttributedString(style: .body3) ??
             "날짜 미정".pretendardAttributedString(style: .body3)
         pinImageView.isHidden = !model.isPinned
-        //setUpMenu(isPinned: model.isPinned)
+        setUpMenu(with: model)
 
         if let imageURL = model.imageURL, !imageURL.isEmpty,
            let url = URL(string: imageURL) {

--- a/GILLsDREAM-iOS/Presentation/PlanList/ViewController/PlanListViewController.swift
+++ b/GILLsDREAM-iOS/Presentation/PlanList/ViewController/PlanListViewController.swift
@@ -15,6 +15,8 @@ final class PlanListViewController: BaseViewController {
     private let viewModel = PlanListViewModel()
     private let disposeBag = DisposeBag()
     private let refreshControl = UIRefreshControl()
+    private let pdfRequestRelay = PublishRelay<Plan>()
+    private let pdfAnchorRelay = PublishRelay<UIView>()
     var onSelectPlan: ((Int) -> Void)?
 
     override func loadView() {
@@ -46,7 +48,8 @@ final class PlanListViewController: BaseViewController {
         // 최초 1회 + 당겨서 새로고침 둘 다 fetch 트리거로 사용
         let input = PlanListViewModel.Input(
             viewDidLoad: Observable.merge(firstAppear, pullToRefresh),
-            itemSelected: rootView.myPlanCollectionView.rx.modelSelected(Plan.self).asObservable()
+            itemSelected: rootView.myPlanCollectionView.rx.modelSelected(Plan.self).asObservable(),
+            pdfRequested: pdfRequestRelay.asObservable()
         )
 
         let output = viewModel.transform(input: input)
@@ -60,6 +63,15 @@ final class PlanListViewController: BaseViewController {
                 guard let self else { return }
                 let plans = sections.flatMap { $0.items }
                 self.rootView.noPlanLabel.isHidden = !plans.isEmpty
+            })
+            .disposed(by: disposeBag)
+        
+        output.exportedPDFURL
+            .emit(onNext: { [weak self] url in
+                guard let self else { return }
+                let activity = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                activity.popoverPresentationController?.sourceView = self.view
+                self.present(activity, animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -105,8 +117,9 @@ final class PlanListViewController: BaseViewController {
                 self?.viewModel.togglePin(for: item)
             }
 
-            cell.onConvertToPDF = {
-                // TODO: PDF 변환 로직
+            cell.onConvertToPDF = { [weak self] plan, anchor in
+                self?.pdfAnchorRelay.accept(anchor)
+                self?.pdfRequestRelay.accept(plan)
             }
 
             cell.onShare = {

--- a/GILLsDREAM-iOS/Presentation/PlanList/ViewModel/PlanListViewModel.swift
+++ b/GILLsDREAM-iOS/Presentation/PlanList/ViewModel/PlanListViewModel.swift
@@ -64,12 +64,14 @@ final class PlanListViewModel {
                     return try await self.usecase.exportPlanPDF(planId: plan.id, title: plan.title)
                 }
                 .asObservable()
-                .do(onError: { [weak self] _ in
+                .catch { [weak self] _ in
                     self?.errorRelay.accept("PDF 내보내기에 실패했어요. 잠시 후 다시 시도해 주세요.")
-                })
-                .catchAndReturn(URL(fileURLWithPath: "plan"))
+                    return .empty()
+                }
             }
-            .filter { !$0.path.isEmpty }
+            .filter {
+                FileManager.default.fileExists(atPath: $0.path)
+            }
             .bind(to: exportedPDFRelay)
             .disposed(by: disposeBag)
         

--- a/GILLsDREAM-iOS/Presentation/PlanList/ViewModel/PlanListViewModel.swift
+++ b/GILLsDREAM-iOS/Presentation/PlanList/ViewModel/PlanListViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 오연서 on 8/4/25.
 //
 
+import Foundation
 import RxSwift
 import RxCocoa
 
@@ -18,16 +19,19 @@ final class PlanListViewModel {
     struct Input {
         let viewDidLoad: Observable<Void>
         let itemSelected: Observable<Plan>
+        let pdfRequested: Observable<Plan>
     }
     
     struct Output {
         let planSections: Driver<[PlanSection]>
         let selectedPlan: Signal<Plan>
+        let exportedPDFURL: Signal<URL>
         let errorMessage: Signal<String>
         let isLoading: Driver<Bool>
     }
     
     private let planSectionsRelay = BehaviorRelay<[PlanSection]>(value: [])
+    private let exportedPDFRelay = PublishRelay<URL>()
     private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
     private let errorRelay = PublishRelay<String>()
     private let disposeBag = DisposeBag()
@@ -51,9 +55,28 @@ final class PlanListViewModel {
             .bind(to: planSectionsRelay)
             .disposed(by: disposeBag)
         
+        input.pdfRequested
+            .flatMapLatest { [weak self] plan -> Observable<URL> in
+                guard let self else { return .empty() }
+                return RxAsync.run {
+                    await MainActor.run { self.isLoadingRelay.accept(true) }
+                    defer { Task { @MainActor in self.isLoadingRelay.accept(false) } }
+                    return try await self.usecase.exportPlanPDF(planId: plan.id, title: plan.title)
+                }
+                .asObservable()
+                .do(onError: { [weak self] _ in
+                    self?.errorRelay.accept("PDF 내보내기에 실패했어요. 잠시 후 다시 시도해 주세요.")
+                })
+                .catchAndReturn(URL(fileURLWithPath: "plan"))
+            }
+            .filter { !$0.path.isEmpty }
+            .bind(to: exportedPDFRelay)
+            .disposed(by: disposeBag)
+        
         return Output(
             planSections: planSectionsRelay.asDriver(),
             selectedPlan: input.itemSelected.asSignal(onErrorSignalWith: .empty()),
+            exportedPDFURL: exportedPDFRelay.asSignal(),
             errorMessage: errorRelay.asSignal(),
             isLoading: isLoadingRelay.asDriver()
         )


### PR DESCRIPTION
<!--
name: PR template
title: "[Prefix/#ISSUE_NUMBER] description"
labels: ''
assignees: ''
-->

### 🍰 연관된 이슈
> close: #67 
> 
### 🥐 Description
- 여행 제목의 '/' 와 ':'는 '_'로 대체하여 변환하였습니다.
- await exportPlanPDF() 호출만 하고 리턴값(URL)을 안 쓰는 경우를 고려하여 @discardableResult를 붙여줬습니다.
- 다음은.. 카카오톡 공유하기

### 🍿 Screenshots


### 🍳 References


### 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Export any plan as a PDF directly from the plan list.
  - Open the exported PDF in the iOS share sheet to save or share instantly.

- **Improvements**
  - Simplified plan cell menu to make PDF export quicker and more prominent.
  - Added in-list export workflow with visual anchoring for a smoother UX.

- **Chores**
  - App version bumped to 1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->